### PR TITLE
dispay users in column. order user by vote

### DIFF
--- a/src/components/SessionResults/index.jsx
+++ b/src/components/SessionResults/index.jsx
@@ -16,6 +16,22 @@ function SessionResults({ session }) {
 
   const getUserVote = user => session.votes && session.votes[user];
 
+  const userComparator = (sessionUserA, sessionUserB) => {
+    const userVoteA = getUserVote(sessionUserA);
+    const userVoteB = getUserVote(sessionUserB);
+
+    if (userVoteA < userVoteB || (userVoteA && !userVoteB)){
+      return -1;
+    }
+
+    if (userVoteA > userVoteB){
+      return 1;
+    }
+
+    return 0;
+  }
+  session.users.sort(userComparator);
+
   return (
     <Box align="start" gap="small" background="neutral-4" pad="small">
       <Heading level="2" margin="none" size="small">
@@ -27,7 +43,7 @@ function SessionResults({ session }) {
         label="Reveal results"
         onChange={handleRevealChange}
       />
-      <Box direction="row" gap="small" wrap>
+      <Box direction="column" gap="small" wrap>
         {session.users &&
           session.users.map(sessionUser => {
             const userVote = getUserVote(sessionUser);
@@ -39,6 +55,7 @@ function SessionResults({ session }) {
               <Box
                 key={`session_user_${sessionUser}`}
                 direction="row"
+                justify="between"
                 border={boxBorder}
                 margin={{ bottom: "small" }}
               >

--- a/src/components/SessionResults/index.jsx
+++ b/src/components/SessionResults/index.jsx
@@ -30,7 +30,10 @@ function SessionResults({ session }) {
 
     return 0;
   }
-  session.users.sort(userComparator);
+
+  if(session.reveal) {
+    session.users.sort(userComparator);
+  }
 
   return (
     <Box align="start" gap="small" background="neutral-4" pad="small">


### PR DESCRIPTION
I am not sure, but may be this changes make sense.
Order users by vote. Display users in column.  Add space between user name and vote.
We have now
![image](https://user-images.githubusercontent.com/55498480/66647746-66479d00-ec32-11e9-9a28-9fdee6356c45.png)
After chnages
![image](https://user-images.githubusercontent.com/55498480/66647764-765f7c80-ec32-11e9-8a1d-319ebe10dec2.png)
